### PR TITLE
Add missing Lib to target_link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,6 @@ find_package( OpenCV REQUIRED )
 
 
 target_link_libraries(mmaldemo mmal_core mmal_util mmal_vc_client vcos bcm_host)
-target_link_libraries(mmal_buffer_demo mmal_core mmal_util mmal_vc_client vcos bcm_host)
-target_link_libraries(mmal_opencv_demo mmal_core mmal_util mmal_vc_client vcos bcm_host ${OpenCV_LIBS} vgfont openmaxil EGL)
-target_link_libraries(mmal_video_record mmal_core mmal_util mmal_vc_client vcos bcm_host cairo)
+target_link_libraries(mmal_buffer_demo mmal_core mmal_util mmal_vc_client vcos bcm_host rt)
+target_link_libraries(mmal_opencv_demo mmal_core mmal_util mmal_vc_client vcos bcm_host ${OpenCV_LIBS} vgfont openmaxil EGL  pthread rt m freetype)
+target_link_libraries(mmal_video_record mmal_core mmal_util mmal_vc_client vcos bcm_host cairo rt)


### PR DESCRIPTION
###### 

Linking C executable mmal_buffer_demo
Error :
undefined reference to symbol 'clock_gettime@@GLIBC_2.4'

Add Lib rt
###### 

Linking C executable mmal_opencv_demo
Error : 
undefined reference to symbol 'sem_post@@GLIBC_2.4'
undefined reference to symbol 'clock_gettime@@GLIBC_2.4'
undefined reference to symbol 'lrint@@GLIBC_2.4'
undefined reference to symbol 'FT_New_Face'

Add Lib pthread rt m freetype
###### 

Linking C executable mmal_video_record
Error :
undefined reference to symbol 'clock_gettime@@GLIBC_2.4'

Add Lib rt
###### 
